### PR TITLE
Treat every message as a reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Inspired by Reddit's modmail system.
 3. Create a Discord server to be used as the modmail inbox
 4. Copy `config.example.json` to `config.json` and fill in the values
 5. Install dependencies: `npm install`
-6. Run the bot: `node src/index.js`
+6. Add bot to servers, and make sure to give it proper permissions on the mail server.
+7. Run the bot: `node src/index.js`
 
 ## Commands
 
@@ -22,8 +23,10 @@ Inspired by Reddit's modmail system.
 
 ##### Inside a modmail thread
 `!reply <text>` Sends a reply to the user in the format "(Role) User: text" (alias `!r`)  
-`!anonreply <text>` Sends an anonymous reply to the user in the format "Role: text"  
+`!anonreply <text>` Sends an anonymous reply to the user in the format "Role: text" (alias !ar) 
 `!close` Closes the modmail thread and saves a log of it  
 `!logs` Lists previous modmail logs with this user  
 `!block` Blocks the user from using modmail  
 `!unblock` Unblocks the user from using modmail
+
+To automatically reply without using !reply or !r, enable `alwaysReply` in the config. `alwaysReplyAnon` sets whether to reply anonymously. If you do not wish to reply, it will ignore any message starting in the prefix (which defaults to !), such as !note

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,11 @@
 {
   "token": "your bot token",
   "mailGuildId": "id of the modmail inbox guild",
-  "mainGuildId": "id of the main server where users will DM the bot"
+  "mainGuildId": "id of the main server where users will DM the bot",
+
+  "prefix": "!",
+  "status": "Message me for help!",
+  "responseMessage": "Thank you for your message! Our mod team will reply to you here as soon as possible.",
+  "alwaysReply": false,
+  "alwaysReplyAnon": false
 }

--- a/src/index.js
+++ b/src/index.js
@@ -57,15 +57,18 @@ function formatUserDM(msg) {
   });
 }
 
-bot.on('messageCreate', msg => {
-  if (! msg.channel.guild) return;
-  if (msg.channel.guild.id !== utils.getModmailGuild(bot).id) return;
-  if (! msg.member.permission.has('manageRoles')) return;
-  if (msg.author.bot) return;
-  if (msg.content[0] == bot.commandOptions.prefix) return;
+// "Forward all messages not starting in prefix"
+if (config.alwaysReply) {
+  bot.on('messageCreate', msg => {
+    if (! msg.channel.guild) return;
+    if (msg.channel.guild.id !== utils.getModmailGuild(bot).id) return;
+    if (! msg.member.permission.has('manageRoles')) return;
+    if (msg.author.bot) return;
+    if (msg.content[0] == bot.commandOptions.prefix) return;
 
-  reply(msg, msg.content.trim(), false);
-});
+    reply(msg, msg.content.trim(), config.alwaysReplyAnon || false);
+  });
+}
 
 // "Bot was mentioned in #general-discussion"
 bot.on('messageCreate', msg => {
@@ -161,7 +164,7 @@ Here's what their message contained:
             });
 
             // Send an automatic reply to the user informing them of the successfully created modmail thread
-            msg.channel.createMessage("Thank you for your message! Our mod team will reply to you here as soon as possible.").then(null, (err) => {
+            msg.channel.createMessage(config.responseMessage || "Thank you for your message! Our mod team will reply to you here as soon as possible.").then(null, (err) => {
               bot.createMessage(utils.getModmailGuild(bot).id, {
                 content: `There is an issue sending messages to ${msg.author.username}#${msg.author.discriminator} (id ${msg.author.id}); consider messaging manually`
               });

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,16 @@ function formatUserDM(msg) {
   });
 }
 
+bot.on('messageCreate', msg => {
+  if (! msg.channel.guild) return;
+  if (msg.channel.guild.id !== utils.getModmailGuild(bot).id) return;
+  if (! msg.member.permission.has('manageRoles')) return;
+  if (msg.author.bot) return;
+  if (msg.content[0] == bot.commandOptions.prefix) return;
+
+  reply(msg, msg.content.trim(), false);
+});
+
 // "Bot was mentioned in #general-discussion"
 bot.on('messageCreate', msg => {
   if (msg.author.id === bot.user.id) return;


### PR DESCRIPTION
Thank you for this very useful bot! It was annoying to have to write !r at the beginning of every message in order to reply to someone. With this commit, any message in the channel that doesn't start with the prefix will be treated as a reply, leading to much more natural conversations.