### PR TITLE
Implement typing proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ These go in `config.json`. See also `config.example.json`.
 |alwaysReplyAnon|false|If `alwaysReply` is set to true, this option controls whether the auto-reply is anonymous|
 |useNicknames|false|If set to true, mod replies will use their nickname (on the inbox server) instead of their username|
 |ignoreAccidentalThreads|false|If set to true, the bot attempts to ignore common "accidental" messages that would start a new thread, such as "ok", "thanks", etc.|
+|typingProxy|false|If set to true, the bot will start typing in the corresponding modmail channel when the user starts typing in DM.
+|typingProxyReverse|false|If set to true, the bot will start typing in the user's DM when someone starts typing in the corresponding thread.
 |enableGreeting|false|Set to true to send a welcome message to new main guild members. Requires `mainGuildId` to be set.|
 |greetingMessage|None|Text content of the welcome message|
 |greetingAttachment|None|Path to an image or other attachment to send along with the greeting|

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,8 @@ const defaultConfig = {
   "alwaysReplyAnon": false,
   "useNicknames": false,
   "ignoreAccidentalThreads": false,
+  "typingProxy": false,
+  "typingProxyReverse": false,
 
   "enableGreeting": false,
   "greetingMessage": null,

--- a/src/index.js
+++ b/src/index.js
@@ -183,9 +183,14 @@ if(config.typingProxy || config.typingProxyReverse) {
     else if(config.typingProxyReverse && (channel instanceof Eris.GuildChannel) && ! user.bot) {
       thread = await threads.getByChannelId(channel.id);
       if (! thread) return;
-      let dm;
-      dm = await bot.getDMChannel(thread.userId);
-      bot.sendChannelTyping(dm.id);
+      try {
+        let dm;
+        dm = await bot.getDMChannel(thread.userId);
+        bot.sendChannelTyping(dm.id);
+      }
+      catch(error) {
+        console.log("An error occured when trying to type in DM.");
+      }
     }
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,6 @@ bot.on('messageUpdate', async (msg, oldMessage) => {
 // Subscribe to typingStart if it's enabled either way
 if(config.typingProxy || config.typingProxyReverse) {
   bot.on("typingStart", async (channel, user) => {
-    //bot.sendChannelTyping(channel.id);
     // Handle user typing to modmail in DM
     if(config.typingProxy && (channel instanceof Eris.PrivateChannel)) {
       thread = await threads.getForUser(user, false);

--- a/src/index.js
+++ b/src/index.js
@@ -170,6 +170,27 @@ bot.on('messageUpdate', async (msg, oldMessage) => {
   bot.createMessage(thread.channelId, editMessage);
 });
 
+// Subscribe to typingStart if it's enabled either way
+if(config.typingProxy || config.typingProxyReverse) {
+  bot.on("typingStart", async (channel, user) => {
+    //bot.sendChannelTyping(channel.id);
+    // Handle user typing to modmail in DM
+    if(config.typingProxy && (channel instanceof Eris.PrivateChannel)) {
+      thread = await threads.getForUser(user, false);
+      if (! thread) return;
+      bot.sendChannelTyping(thread.channelId);
+    }
+    // Handle agent typing in thread
+    else if(config.typingProxyReverse && (channel instanceof Eris.GuildChannel) && ! user.bot) {
+      thread = await threads.getByChannelId(channel.id);
+      if (! thread) return;
+      let dm;
+      dm = await bot.getDMChannel(thread.userId);
+      bot.sendChannelTyping(dm.id);
+    }
+  });
+}
+
 /**
  * Sends a reply to the modmail thread where `msg` was posted.
  * @param {Eris.Message} msg


### PR DESCRIPTION
This implements #43. when a user starts typing in a DM, the bot will start typing in the corresponding thread and vice-versa.
