### PR TITLE
User configurable mentions

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   "responseMessage": "Thank you for your message! Our mod team will reply to you here as soon as possible.",
 
   "newThreadCategoryId": null,
+  "mentionRoleID": null,
 
   "inboxServerPermission": null,
   "alwaysReply": false,

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -79,9 +79,12 @@ async function createNewThreadForUser(user) {
 
   const newThread = await findById(newThreadId);
 
+  //If no role is set, mention @here
+  const mention = (config.mentionRoleID == null) ? "@here" : `<@&${config.mentionRoleID}>`;
+
   // Ping moderators of the new thread
   await newThread.postNonLogMessage({
-    content: `@here New modmail thread (${newThread.user_name})`,
+    content: `${mention} New modmail thread (${newThread.user_name})`,
     disableEveryone: false
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -140,8 +140,11 @@ bot.on('messageCreate', async msg => {
   // If the person who mentioned the bot is blocked, ignore them
   if (await blocked.isBlocked(msg.author.id)) return;
 
+  //If no role is set, mention @here
+  const mention = (config.mentionRoleID == null) ? "@here" : `<@&${config.mentionRoleID}>`;
+
   bot.createMessage(utils.getLogChannel(bot).id, {
-    content: `@here Bot mentioned in ${msg.channel.mention} by **${msg.author.username}#${msg.author.discriminator}**: "${msg.cleanContent}"`,
+    content: `${mention} Bot mentioned in ${msg.channel.mention} by **${msg.author.username}#${msg.author.discriminator}**: "${msg.cleanContent}"`,
     disableEveryone: false,
   });
 });


### PR DESCRIPTION
Hi, 

First of all amazing bot, I just started using it on my server and it's been great.

I added a small feature for us and I thought I'd just push it back to see if you wanted it as well.

If the user adds `mentionRoleID` to the config they can specify a role ID and the bot will ping that rather than `@here`.

Let me know if you want me to change anything.