### PR TITLE
Config: add option for !r/!reply to be anonymous

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -54,6 +54,7 @@ const defaultConfig = {
   "inboxServerPermission": null,
   "alwaysReply": false,
   "alwaysReplyAnon": false,
+  "replyIsAnon": false,
   "useNicknames": false,
   "ignoreAccidentalThreads": false,
   "threadTimestamps": false,

--- a/src/modules/reply.js
+++ b/src/modules/reply.js
@@ -1,12 +1,13 @@
 const attachments = require("../data/attachments");
 const threadUtils = require("../threadUtils");
+const config = require('../config');
 
 module.exports = bot => {
   const addInboxServerCommand = (...args) => threadUtils.addInboxServerCommand(bot, ...args);
 
   // Mods can reply to modmail threads using !r or !reply
   // These messages get relayed back to the DM thread between the bot and the user
-  addInboxServerCommand('reply', async (msg, args, thread) => {
+  addInboxServerCommand('rr', async (msg, args, thread) => {
     if (! thread) return;
 
     const text = args.join(' ').trim();
@@ -14,8 +15,6 @@ module.exports = bot => {
     await thread.replyToUser(msg.member, text, msg.attachments, false);
     msg.delete();
   });
-
-  bot.registerCommandAlias('r', 'reply');
 
   // Anonymous replies only show the role, not the username
   addInboxServerCommand('anonreply', async (msg, args, thread) => {
@@ -27,5 +26,15 @@ module.exports = bot => {
     msg.delete();
   });
 
+  bot.registerCommandAlias('regreply', 'rr');
   bot.registerCommandAlias('ar', 'anonreply');
+
+  if (config.replyIsAnon) {
+    bot.registerCommandAlias('r', 'anonreply');
+    bot.registerCommandAlias('reply', 'anonreply');
+  }
+  else {
+    bot.registerCommandAlias('r', 'rr');
+    bot.registerCommandAlias('reply', 'rr');
+  }
 };

--- a/src/modules/snippets.js
+++ b/src/modules/snippets.js
@@ -25,14 +25,14 @@ module.exports = bot => {
     const snippet = await snippets.get(trigger);
     if (! snippet) return;
 
-    await thread.replyToUser(msg.member, snippet.body, [], !! snippet.is_anonymous);
+    await thread.replyToUser(msg.member, snippet.body, [], (!! snippet.is_anonymous) || config.replyIsAnon);
     msg.delete();
   });
 
   // Show or add a snippet
   addInboxServerCommand('snippet', async (msg, args, thread) => {
     const trigger = args[0];
-    if (! trigger) return
+    if (! trigger) return;
 
     const text = args.slice(1).join(' ').trim();
     const snippet = await snippets.get(trigger);


### PR DESCRIPTION
This changes the base command to `rr` and simply aliases the command based on whether or not the config option is set to true. Also makes snippets always reply anonymously. `rr` and `regreply` will reply with the name regardless of the config option.

This was mainly something my own modmail team asked for but decided to PR it back. let me know if changes are needed.