### PR TITLE
Fixing issue with offline users

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,12 +1,13 @@
 const Eris = require('eris');
 const config = require('./config');
 
-const bot = new Eris.CommandClient(config.token, {}, {
+const bot = new Eris.CommandClient(config.token, {
+  getAllUsers: true,
+}, {
   prefix: config.prefix,
   ignoreSelf: true,
   ignoreBots: true,
   defaultHelpCommand: false,
-  getAllUsers: true,
   defaultCommandOptions: {
     caseInsensitive: true,
   },


### PR DESCRIPTION
Hi there,

We recently upgraded a fork of our modmail bot and noticed that, for certain users, the header for the mod mail thread (i.e. account age, ID etc.) wasn't being sent.

After going through the code we boiled it down to a configuration problem with constructing the Eris `CommandClient` class. We knew this because the users that had the issue after we restarted the bot were all "offline" in Discord and unless `getAllUsers` is set in Eris's config those users won't be cached.

Hence this caused an exception in forming the thread header.

As per the constructor for Eris's `CommandClient` class, the second parameter is the one forwarded to the actual `Client` class so there is where `getAllUsers` should be.

Here's a pull request for that! Thanks for your wonderful work in making this by the way! <3

Cheers,

Dylan