### PR TITLE
Error catch, prevents app crash on errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -179,6 +179,8 @@ bot.on('messageCreate', async msg => {
   }
 });
 
+bot.on("error", console.error);
+
 module.exports = {
   async start() {
     // Load modules


### PR DESCRIPTION
I noticed that the bot crashed when it ran into a websocket error that was either caused by my host losing connection or discord servers going offline. I added in a small line of code that catches any error and puts it in console instead of crashing the program.