### PR TITLE
TypeError on no config and with process.env.PORT

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -146,6 +146,7 @@ for (const [key, value] of Object.entries(process.env)) {
 
 if (process.env.PORT && !process.env.MM_PORT) {
   // Special case: allow common "PORT" environment variable without prefix
+  !userConfig ? userConfig = {} : null;
   userConfig.port = process.env.PORT;
   loadedEnvValues++;
 }


### PR DESCRIPTION
For users that have process.env.PORT no MM_PORT, config.json or config.ini,  modmail will not start as userConfig is null and will throw a typeError. This PR isn't important but it's still better to have a missing config error than a typeError (confusing to people that never coded before)