### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Inspired by Reddit's modmail system.
 If you need help with setting up the bot or would like to discuss other things related to it, join the support server on Discord here:
 
 👉 **[Join support server](https://discord.gg/vRuhG9R)**
+
+[![Run on Repl.it](https://repl.it/badge/github/Dragory/modmailbot)](https://repl.it/github/Dragory/modmailbot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).