### PR TITLE
Add optional automatic thread creation on mention

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,6 +254,10 @@ The bot's "Playing" text
 **Default:** `on`  
 If enabled, channel permissions for the thread are synchronized with the category when using `!move`. Requires `allowMove` to be enabled.
 
+#### threadOnMention
+**Default:** `off`  
+If enabled, the bot will automatically create a new thread for a user who pings it.
+
 #### threadTimestamps
 **Default:** `off`  
 If enabled, modmail threads will show accurate UTC timestamps for each message, in addition to Discord's own timestamps.

--- a/src/config.js
+++ b/src/config.js
@@ -76,6 +76,7 @@ const defaultConfig = {
   "mentionRole": "here",
   "pingOnBotMention": true,
   "botMentionResponse": null,
+  "threadOnMention": false,
 
   "inboxServerPermission": null,
   "alwaysReply": false,

--- a/src/main.js
+++ b/src/main.js
@@ -229,6 +229,17 @@ function initBaseMessageHandlers() {
       const botMentionResponse = utils.readMultilineConfigValue(config.botMentionResponse);
       bot.createMessage(msg.channel.id, botMentionResponse.replace(/{userMention}/g, `<@${msg.author.id}>`));
     }
+
+    // If configured, automatically open a new thread with a user who has pinged it
+    if (config.threadOnMention) {
+       if (await blocked.isBlocked(msg.author.id)) return;  // This may not be needed as it is checked above.
+       if (utils.isStaff(msg.member)) return;               // Same.
+       const existingThread = await threads.findOpenThreadByUserId(msg.author.id);
+       if (existingThread) {                                // Already a thread open; nothing to do
+          return;
+       }
+       const createdThread = await threads.createNewThreadForUser(msg.author, true, true);
+    }
   });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -235,10 +235,9 @@ function initBaseMessageHandlers() {
        if (await blocked.isBlocked(msg.author.id)) return;  // This may not be needed as it is checked above.
        if (utils.isStaff(msg.member)) return;               // Same.
        const existingThread = await threads.findOpenThreadByUserId(msg.author.id);
-       if (existingThread) {                                // Already a thread open; nothing to do
-          return;
+       if (! existingThread) {                                // Only open a thread if we don't already have one.
+          const createdThread = await threads.createNewThreadForUser(msg.author, true, true);
        }
-       const createdThread = await threads.createNewThreadForUser(msg.author, true, true);
     }
   });
 }


### PR DESCRIPTION
Add an option to have the bot automatically open a
new thread when a user @s the bot in a monitored
channel.  Modify configuration parser to handle the
new settings; add a stanza to the configuration
documentiaion for it.

Implements #391