### PR TITLE
Added anonymizeChannelName configuration option.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,6 +313,10 @@ URL to use for attachment and log links. Defaults to `http://IP:PORT`.
 **Default:** `off`  
 If enabled, mod replies will use their nicknames (on the inbox server) instead of their usernames
 
+#### anonymizeChannelName
+**Default:** `off`
+If enabled, channel names will be the user's name and discriminator salted with the current time, then hashed to protect the user's privacy
+
 ## Advanced options
 
 #### extraIntents

--- a/src/data/cfg.schema.json
+++ b/src/data/cfg.schema.json
@@ -124,6 +124,10 @@
       "$ref": "#/definitions/customBoolean",
       "default": false
     },
+    "anonymizeChannelName": {
+      "$ref": "#/definitions/customBoolean",
+      "default": false
+    },
     "ignoreAccidentalThreads": {
       "$ref": "#/definitions/customBoolean",
       "default": false

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -4,6 +4,7 @@ const transliterate = require("transliteration");
 const moment = require("moment");
 const uuid = require("uuid");
 const humanizeDuration = require("humanize-duration");
+const crypto = require("crypto");
 
 const bot = require("../bot");
 const knex = require("../knex");
@@ -135,7 +136,13 @@ async function createNewThreadForUser(user, opts = {}) {
   if (cleanName === "") cleanName = "unknown";
   cleanName = cleanName.slice(0, 95); // Make sure the discrim fits
 
-  const channelName = `${cleanName}-${user.discriminator}`;
+  let temporalName = `${cleanName}-${user.discriminator}`;
+
+  if (config.anonymizeChannelName) {
+    temporalName = crypto.createHash("md5").update(temporalName + new Date()).digest("hex").slice(0, 12);
+  }
+
+  const channelName = temporalName;
 
   console.log(`[NOTE] Creating new thread channel ${channelName}`);
 


### PR DESCRIPTION
This is mostly useful for single server setups.

The channel lists can be publicly seen even if users don't have permissions to view it if they're using modded clients like Better Discord or Enhanced Discord, so this is just an additional measure to protect the privacy of the users using the modmail.

Tested on a server with 36k members, seems to work fine so far. 