### PR TITLE
Fix snippet took as language identifier

### DIFF
--- a/src/modules/snippets.js
+++ b/src/modules/snippets.js
@@ -83,7 +83,7 @@ module.exports = ({ bot, knex, config, commands }) => {
         utils.postSystemMessageWithFallback(msg.channel, thread, `Snippet "${args.trigger}" already exists! You can edit or delete it with ${config.prefix}edit_snippet and ${config.prefix}delete_snippet respectively.`);
       } else {
         // If the snippet exists and we're NOT trying to create a new one, show info about the existing snippet
-        utils.postSystemMessageWithFallback(msg.channel, thread, `\`${config.snippetPrefix}${args.trigger}\` replies with: \`\`\`${utils.disableCodeBlocks(snippet.body)}\`\`\``);
+        utils.postSystemMessageWithFallback(msg.channel, thread, `\`${config.snippetPrefix}${args.trigger}\` replies with: \`\`\`\n${utils.disableCodeBlocks(snippet.body)}\`\`\``);
       }
     } else {
       if (args.text) {


### PR DESCRIPTION
Added a new line so it doesn't take snippet as language identifier.
Without this new line, if the first line of the snippet contains only one word (if it doesn't have at least 1 space character), the first line is taken as a language identifier, unknown in most cases.
Just added `\n` to avoid using snippet as a language identifier.