### PR TITLE
Document silent close, allow silent to be passed like other options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,6 +28,9 @@ Close the Modmail thread after a timer. Sending a message to the user or receivi
 
 **Example:** `!close 15m`
 
+### `!close -s` / `!close -s <time>`
+Close the Modmail thread without notifying the user that it was closed.
+
 ### `!close cancel`
 Cancel a timed close.
 

--- a/src/modules/close.js
+++ b/src/modules/close.js
@@ -104,7 +104,7 @@ module.exports = ({ bot, knex, config, commands }) => {
         }
 
         // Silent close (= no close message)
-        if (args.opts.includes("silent") || args.opts.includes("s")) {
+        if (args.opts.includes("silent") || args.opts.includes("s") || args.opts.includes("-s")) {
           silentClose = true;
         }
 


### PR DESCRIPTION
Documents that closing a thread silently is possible, and allows passing this option in the same way that `loglink` accepts its options.
