### PR TITLE
allow the mentionRole setting to accept more than one string

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,7 +313,7 @@ If enabled, the bot will react to messages sent to it with the emoji defined in 
 #### reactOnSeenEmoji
 **Default:** `📨`  
 The emoji that the bot will react with when it sees a message.  Requires `reactOnSeen` to be enabled.  
-Must be pasted in the config file as the Emoji representation and not as a unicode codepoint.
+Must be pasted in the config file as the Emoji representation and not as a unicode codepoint. Use `emojiName:emojiID` for custom emoji.
 
 #### relaySmallAttachmentsAsAttachments
 **Default:** `off`  


### PR DESCRIPTION
This fixes #549

Fix is taken from the support Discord https://discord.com/channels/621406760430731325/621406922175676417/806184696870076477