### PR TITLE
Add option to break any formatting in usernames

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,6 +202,10 @@ See [allowInlineSnippets](#allowInlineSnippets) for more details.
 **Default:** *None*  
 Role name to display in moderator replies if the moderator doesn't have a hoisted role
 
+#### breakFormattingForNames
+**Default:** `on`
+Whether or not to escape formatting characters in usernames, such as `~~` for strikethrough, `__` for underlined etc.
+
 #### greetingAttachment
 **Default:** *None*  
 Path to an image or other attachment to send as a greeting. Requires `enableGreeting` to be enabled.

--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -15,7 +15,7 @@ const ThreadMessage = require("./ThreadMessage");
 
 const {THREAD_MESSAGE_TYPE, THREAD_STATUS, DISCORD_MESSAGE_ACTIVITY_TYPES} = require("./constants");
 
-const escapeFormattingRegex = new RegExp("[_`~*]", "g");
+const escapeFormattingRegex = new RegExp("[_`~*|]", "g");
 
 /**
  * @property {String} id

--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -15,6 +15,8 @@ const ThreadMessage = require("./ThreadMessage");
 
 const {THREAD_MESSAGE_TYPE, THREAD_STATUS, DISCORD_MESSAGE_ACTIVITY_TYPES} = require("./constants");
 
+const escapeFormattingRegex = new RegExp("[_`~*]", "g");
+
 /**
  * @property {String} id
  * @property {Number} thread_number
@@ -212,7 +214,10 @@ class Thread {
    * @returns {Promise<boolean>} Whether we were able to send the reply
    */
   async replyToUser(moderator, text, replyAttachments = [], isAnonymous = false) {
-    const moderatorName = config.useNicknames && moderator.nick ? moderator.nick : moderator.user.username;
+    let moderatorName = config.useNicknames && moderator.nick ? moderator.nick : moderator.user.username;
+    if (config.breakFormattingForNames) {
+      moderatorName = moderatorName.replace(escapeFormattingRegex, "\\$&");
+    }
     const roleName = await getModeratorThreadDisplayRoleName(moderator, this.id);
 
     if (config.allowSnippets && config.allowInlineSnippets) {

--- a/src/data/cfg.jsdoc.js
+++ b/src/data/cfg.jsdoc.js
@@ -65,6 +65,7 @@
  * @property {boolean} [errorOnUnknownInlineSnippet=true]
  * @property {boolean} [allowChangingDisplayRole=true]
  * @property {string} [fallbackRoleName=null]
+ * @property {boolean} [breakFormattingForNames=true]
  * @property {boolean} [autoAlert=false]
  * @property {string} [autoAlertDelay="2m"] Delay before auto-alert kicks in. Uses the same format as timed close; for example 1m30s for 1 minute and 30 seconds.
  * @property {boolean} [pinThreadHeader=false]

--- a/src/data/cfg.schema.json
+++ b/src/data/cfg.schema.json
@@ -357,6 +357,11 @@
       "default": null
     },
 
+    "breakFormattingForNames": {
+      "$ref": "#/definitions/customBoolean",
+      "default": true
+    },
+
     "autoAlert": {
       "$ref": "#/definitions/customBoolean",
       "default": false


### PR DESCRIPTION
Defaults to on.

In the following example, messages with odd numbers have the option enabled, even numbers disabled.
![Example Image](https://user-images.githubusercontent.com/7890309/109040004-bc08d200-76cd-11eb-9a8f-1c5dc35e3c2d.png)
