### PR TITLE
Allow adding prefixes before usernames in replies

### DIFF
--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -6,6 +6,7 @@ const knex = require("../knex");
 const utils = require("../utils");
 const config = require("../cfg");
 const attachments = require("./attachments");
+const prefixes = require("./prefixes");
 const { formatters } = require("../formatters");
 const { callAfterThreadCloseHooks } = require("../hooks/afterThreadClose");
 const snippets = require("./snippets");
@@ -273,8 +274,9 @@ class Thread {
     });
     const threadMessage = await this._addThreadMessageToDB(rawThreadMessage.getSQLProps());
 
-    const dmContent = formatters.formatStaffReplyDM(threadMessage);
-    const inboxContent = formatters.formatStaffReplyThreadMessage(threadMessage);
+    const prefix = await prefixes.getPrefix(moderator.id);
+    const dmContent = formatters.formatStaffReplyDM({ ...threadMessage, prefix });
+    const inboxContent = formatters.formatStaffReplyThreadMessage({ ...threadMessage, prefix });
 
     // Because moderator replies have to be editable, we enforce them to fit within 1 message
     if (! utils.messageContentIsWithinMaxLength(dmContent) || ! utils.messageContentIsWithinMaxLength(inboxContent)) {
@@ -801,8 +803,9 @@ class Thread {
       body: newText,
     });
 
-    const formattedThreadMessage = formatters.formatStaffReplyThreadMessage(newThreadMessage);
-    const formattedDM = formatters.formatStaffReplyDM(newThreadMessage);
+    const prefix = await prefixes.getPrefix(moderator.id);
+    const formattedThreadMessage = formatters.formatStaffReplyThreadMessage({ ...newThreadMessage, prefix });
+    const formattedDM = await formatters.formatStaffReplyDM({ ...newThreadMessage, prefix });
 
     // Same restriction as in replies. Because edits could theoretically change the number of messages a reply takes, we enforce replies
     // to fit within 1 message to avoid the headache and issues caused by that.

--- a/src/data/cfg.jsdoc.js
+++ b/src/data/cfg.jsdoc.js
@@ -55,6 +55,7 @@
  * @property {array} [plugins=[]]
  * @property {*} [commandAliases]
  * @property {boolean} [reactOnSeen=false]
+ * @property {boolean} [allowPrefix=true]
  * @property {string} [reactOnSeenEmoji="📨"]
  * @property {boolean} [createThreadOnMention=false]
  * @property {boolean} [notifyOnMainServerLeave=true]

--- a/src/data/cfg.schema.json
+++ b/src/data/cfg.schema.json
@@ -307,6 +307,11 @@
       "default": false
     },
 
+    "allowPrefix": {
+      "$ref": "#/definitions/customBoolean",
+      "default": true
+    },
+
     "reactOnSeenEmoji": {
       "type": "string",
       "default": "\uD83D\uDCE8"

--- a/src/data/migrations/20210422024435_create_nameprefix_table.js
+++ b/src/data/migrations/20210422024435_create_nameprefix_table.js
@@ -1,0 +1,17 @@
+
+exports.up = async function(knex) {
+    if (! await knex.schema.hasTable("name_prefixes")) {
+        await knex.schema.createTable("name_prefixes", table => {
+          table.string("user_id", 20);
+          table.string("prefix", 48);
+    
+          table.primary(["user_id"]);
+        });
+    }
+};
+
+exports.down = async function(knex) {
+    if (await knex.schema.hasTable("name_prefixes")) {
+        await knex.schema.dropTable("name_prefixes");
+    }
+};

--- a/src/data/prefixes.js
+++ b/src/data/prefixes.js
@@ -1,0 +1,60 @@
+const knex = require("../knex");
+const config = require("../cfg");
+
+/**
+ * @param {String} userId
+ * @returns {Promise<string>}
+ */
+ async function getPrefix(userId) {
+  if (! config.allowPrefix || userId == null) return "";
+  const prefixRow = await knex("name_prefixes")
+    .where("user_id", userId)
+    .first();
+
+  return prefixRow ? prefixRow.prefix : "";
+}
+
+/**
+ * Sets prefix for given userId
+ * @param {String} userId
+ * @param {String} prefix
+ * @returns {Promise}
+ */
+async function setPrefix(userId, prefix) {
+  if (! config.allowPrefix) return null;
+  if (await getPrefix(userId)) {
+
+    return knex("name_prefixes")
+    .update({
+      prefix,
+    })
+    .where({
+      user_id: userId,
+    });
+
+  } else {
+
+    return knex("name_prefixes")
+    .insert({
+      user_id: userId,
+      prefix,
+    });
+  }
+}
+
+/**
+ * Removes prefix of given userId
+ * @param {String} userId
+ * @returns {Promise}
+ */
+async function removePrefix(userId) {
+  return knex("name_prefixes")
+    .where("user_id", userId)
+    .delete();
+}
+
+module.exports = {
+  getPrefix,
+  setPrefix,
+  removePrefix,
+};

--- a/src/data/prefixes.js
+++ b/src/data/prefixes.js
@@ -11,7 +11,7 @@ const config = require("../cfg");
     .where("user_id", userId)
     .first();
 
-  return prefixRow ? prefixRow.prefix : "";
+  return prefixRow?.prefix ?? "";
 }
 
 /**

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -104,7 +104,7 @@ const defaultFormatters = {
     const roleName = threadMessage.role_name || config.fallbackRoleName;
     const modInfo = threadMessage.is_anonymous
       ? roleName
-      : (roleName ? `(${roleName}) ${threadMessage.user_name}` : threadMessage.user_name);
+      : (roleName ? `(${roleName}) ${threadMessage.prefix}${threadMessage.user_name}` : `${threadMessage.prefix}${threadMessage.user_name}`);
 
     return modInfo
       ? `**${modInfo}:** ${threadMessage.body}`
@@ -115,7 +115,7 @@ const defaultFormatters = {
     const roleName = threadMessage.role_name || config.fallbackRoleName;
     const modInfo = threadMessage.is_anonymous
       ? (roleName ? `(Anonymous) (${threadMessage.user_name}) ${roleName}` : `(Anonymous) (${threadMessage.user_name})`)
-      : (roleName ? `(${roleName}) ${threadMessage.user_name}` : threadMessage.user_name);
+      : (roleName ? `(${roleName}) ${threadMessage.prefix}${threadMessage.user_name}` : `${threadMessage.prefix}${threadMessage.user_name}`);
 
     let result = modInfo
       ? `**${modInfo}:** ${threadMessage.body}`

--- a/src/main.js
+++ b/src/main.js
@@ -317,6 +317,7 @@ function getBasePlugins() {
     "file:./src/modules/alert",
     "file:./src/modules/joinLeaveNotification",
     "file:./src/modules/roles",
+    "file:./src/modules/prefix",
   ];
 }
 

--- a/src/modules/prefix.js
+++ b/src/modules/prefix.js
@@ -1,0 +1,36 @@
+const prefixes = require("../data/prefixes");
+const MAX_PREFIX_LENGTH = 48;
+
+module.exports = ({ config, commands }) => {
+  commands.addInboxServerCommand("setprefix", "<prefix:string>", async (msg, args) => {
+    if (config.allowPrefix) {
+      if (args.prefix.length > MAX_PREFIX_LENGTH) {
+        await msg.channel.createMessage("Prefix must be 48 characters at most");
+        return;
+      }
+      await prefixes.setPrefix(msg.author.id, args.prefix);
+
+      await msg.channel.createMessage(`Set your reply prefix to \`${args.prefix}\``);
+    }
+  });
+
+  commands.addInboxServerCommand("removeprefix", "", async (msg) => {
+    if (config.allowPrefix) {
+      await prefixes.removePrefix(msg.author.id);
+
+      await msg.channel.createMessage("Removed your reply prefix");
+    }
+  });
+
+  commands.addInboxServerCommand("prefix", "", async (msg) => {
+    if (config.allowPrefix) {
+      const prefix = await prefixes.getPrefix(msg.author.id);
+
+      if (prefix != "") {
+        await msg.channel.createMessage(`Your current prefix is \`${prefix}\``);
+      } else {
+        await msg.channel.createMessage("You currently do not have a reply prefix");
+      }
+    }
+  });
+};


### PR DESCRIPTION
`allowPrefix` is required to set/use prefixes (default true)
`setprefix <prefix:string>` to set new prefix. Using "" allows using spaces after prefix
`removeprefix` to remove prefix
`prefix` to show current prefix
Prefixes are not shown in logs, only on user and mod side