### PR TITLE
Allow certain thread-only commands to be used in suspended threads

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -156,7 +156,11 @@ module.exports = {
           async (_, context) => {
             if (! utils.messageIsOnInboxServer(context.msg)) return false;
             if (! utils.isStaff(context.msg.member)) return false;
-            thread = await threads.findOpenThreadByChannelId(context.msg.channel.id);
+            if (commandConfig.allowSuspended) {
+              thread = await threads.findByChannelId(context.msg.channel.id);
+            } else {
+              thread = await threads.findOpenThreadByChannelId(context.msg.channel.id);
+            }
             if (! thread) return false;
             return true;
           }

--- a/src/modules/alert.js
+++ b/src/modules/alert.js
@@ -7,5 +7,5 @@ module.exports = ({ bot, knex, config, commands }) => {
       await thread.addAlert(msg.author.id);
       await thread.postSystemMessage(`Pinging ${msg.author.username}#${msg.author.discriminator} when this thread gets a new reply`);
     }
-  });
+  }, { allowSuspended: true });
 };

--- a/src/modules/id.js
+++ b/src/modules/id.js
@@ -4,12 +4,12 @@ const utils = require("../utils");
 module.exports = ({ bot, knex, config, commands }) => {
   commands.addInboxThreadCommand("id", [], async (msg, args, thread) => {
     thread.postSystemMessage(thread.user_id);
-  });
+  }, { allowSuspended: true });
 
   commands.addInboxThreadCommand("dm_channel_id", [], async (msg, args, thread) => {
     const dmChannel = await thread.getDMChannel();
     thread.postSystemMessage(dmChannel.id);
-  });
+  }, { allowSuspended: true });
 
   commands.addInboxThreadCommand("message", "<messageNumber:number>", async (msg, args, thread) => {
     /** @type {ThreadMessage} */
@@ -34,5 +34,5 @@ module.exports = ({ bot, knex, config, commands }) => {
     ];
 
     thread.postSystemMessage(parts.join("\n"));
-  });
+  }, { allowSuspended: true });
 };

--- a/src/modules/logs.js
+++ b/src/modules/logs.js
@@ -112,8 +112,12 @@ module.exports = ({ bot, knex, config, commands, hooks }) => {
   commands.addInboxServerCommand("logs", "<userId:userId> [page:number]", logsCmd, { options: logCmdOptions });
   commands.addInboxServerCommand("logs", "[page:number]", logsCmd, { options: logCmdOptions });
 
-  commands.addInboxServerCommand("log", "[threadId:string]", logCmd, { options: logCmdOptions, aliases: ["thread"] });
-  commands.addInboxServerCommand("loglink", "[threadId:string]", logCmd, { options: logCmdOptions });
+  // Add these two overrides to allow using the command in suspended threads
+  commands.addInboxThreadCommand("log", "", logCmd, { options: logCmdOptions, aliases: ["thread"], allowSuspended: true });
+  commands.addInboxThreadCommand("loglink", "", logCmd, { options: logCmdOptions, allowSuspended: true });
+
+  commands.addInboxServerCommand("log", "<threadId:string>", logCmd, { options: logCmdOptions, aliases: ["thread"] });
+  commands.addInboxServerCommand("loglink", "<threadId:string>", logCmd, { options: logCmdOptions });
 
   hooks.afterThreadClose(async ({ threadId }) => {
     const thread = await threads.findById(threadId);

--- a/src/modules/roles.js
+++ b/src/modules/roles.js
@@ -31,7 +31,7 @@ module.exports = ({ bot, knex, config, commands }) => {
     } else {
       thread.postSystemMessage("Your replies in this thread do not currently display a role");
     }
-  });
+  }, { allowSuspended: true });
 
   // Reset display role for a thread
   commands.addInboxThreadCommand("role reset", [], async (msg, args, thread) => {
@@ -45,6 +45,7 @@ module.exports = ({ bot, knex, config, commands }) => {
     }
   }, {
     aliases: ["role_reset", "reset_role"],
+    allowSuspended: true,
   });
 
   // Set display role for a thread
@@ -57,7 +58,7 @@ module.exports = ({ bot, knex, config, commands }) => {
 
     await setModeratorThreadRoleOverride(msg.member.id, thread.id, role.id);
     thread.postSystemMessage(`Your display role for this thread has been set to **${role.name}**. You can reset it with \`${config.prefix}role reset\`.`);
-  });
+  }, { allowSuspended: true });
 
   // Get default display role
   commands.addInboxServerCommand("role", [], async (msg, args, thread) => {

--- a/src/modules/suspend.js
+++ b/src/modules/suspend.js
@@ -41,6 +41,10 @@ module.exports = ({ bot, knex, config, commands }) => {
   });
 
   commands.addInboxThreadCommand("suspend", "[delay:delay]", async (msg, args, thread) => {
+    if (thread.status === THREAD_STATUS.SUSPENDED) {
+      thread.postSystemMessage("Thread is already suspended.");
+      return;
+    }
     if (args.delay) {
       const suspendAt = moment.utc().add(args.delay, "ms");
       await thread.scheduleSuspend(suspendAt.format("YYYY-MM-DD HH:mm:ss"), msg.author);
@@ -52,7 +56,7 @@ module.exports = ({ bot, knex, config, commands }) => {
 
     await thread.suspend();
     thread.postSystemMessage("**Thread suspended!** This thread will act as closed until unsuspended with `!unsuspend`");
-  });
+  }, { allowSuspended: true });
 
   commands.addInboxServerCommand("unsuspend", [], async (msg, args, thread) => {
     if (thread) {


### PR DESCRIPTION
These changes allows certain commands that pass `commandConfig.allowSuspended` to `addInboxThreadCommand` to bypass the requirement to be unsuspended.
Closes #632 