### PR TITLE
Fix crash if message is only the snippet invoke

### DIFF
--- a/src/modules/snippets.js
+++ b/src/modules/snippets.js
@@ -60,7 +60,10 @@ module.exports = ({ bot, knex, config, commands }) => {
     const thread = await threads.findByChannelId(msg.channel.id);
     if (! thread) return;
 
-    let [, trigger, rawArgs] = msg.content.slice(snippetPrefix.length).match(/(\S+)(?:\s+(.*))?/s);
+    const snippetInvoke = msg.content.slice(snippetPrefix.length);
+    if (! snippetInvoke) return;
+
+    let [, trigger, rawArgs] = snippetInvoke.match(/(\S+)(?:\s+(.*))?/s);
     trigger = trigger.toLowerCase();
 
     const snippet = await snippets.get(trigger);


### PR DESCRIPTION
If the message is only the invoke the slice() will create a null object, causing a TypeError in match()