### PR TITLE
Feature/channel name prefix

### DIFF
--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -7,6 +7,7 @@ const utils = require("../utils");
 const config = require("../cfg");
 const attachments = require("./attachments");
 const { formatters } = require("../formatters");
+const { callBeforeNewMessageReceivedHooks } = require("../hooks/beforeNewMessageReceived");
 const { callAfterThreadCloseHooks } = require("../hooks/afterThreadClose");
 const snippets = require("./snippets");
 const { getModeratorThreadDisplayRoleName } = require("./displayRoles");
@@ -327,6 +328,21 @@ class Thread {
    * @returns {Promise<void>}
    */
   async receiveUserReply(msg) {
+    const user = msg.author;
+    const opts = {
+      source: "dm",
+      message: msg,
+    };
+    let hookResult;
+
+    // Call any registered beforeNewMessageReceivedHooks
+    hookResult = await callBeforeNewMessageReceivedHooks({
+      user,
+      opts,
+      message: opts.message
+    });
+    if (hookResult.cancelled) return;
+
     const fullUserName = `${msg.author.username}#${msg.author.discriminator}`;
     let messageContent = msg.content || "";
 

--- a/src/hooks/beforeNewMessageReceived.js
+++ b/src/hooks/beforeNewMessageReceived.js
@@ -1,0 +1,78 @@
+const Eris = require("eris");
+
+/**
+ * @typedef BeforeNewMessageReceivedHookData
+ * @property {Eris.User} user
+ * @property {Eris.Message} [message]
+ * @property {CreateNewThreadForUserOpts} opts
+ * @property {Function} cancel
+ */
+
+/**
+ * @typedef BeforeNewMessageReceivedHookResult
+ * @property {boolean} cancelled
+ */
+
+/**
+ * @callback BeforeNewMessageReceivedHookFn
+ * @param {BeforeNewMessageReceivedHookData} data
+ * @return {void|Promise<void>}
+ */
+
+/**
+ * @callback AddBeforeNewMessageReceivedHookFn
+ * @param {BeforeNewMessageReceivedHookFn} fn
+ * @return {void}
+ */
+
+/**
+ * @type BeforeNewMessageReceivedHookFn[]
+ */
+const beforeNewMessageReceivedHooks = [];
+
+/**
+ * @type {AddBeforeNewMessageReceivedHookFn}
+ */
+let beforeNewMessageReceived; // Workaround to inconsistent IDE bug with @type and anonymous functions
+beforeNewMessageReceived = (fn) => {
+  beforeNewMessageReceivedHooks.push(fn);
+};
+
+/**
+ * @param {{
+ *   user: Eris.User,
+ *   message?: Eris.Message,
+ *   opts: CreateNewThreadForUserOpts,
+ * }} input
+ * @return {Promise<BeforeNewMessageReceivedHookResult>}
+ */
+async function callBeforeNewMessageReceivedHooks(input) {
+  /**
+   * @type {BeforeNewMessageReceivedHookResult}
+   */
+  const result = {
+    cancelled: false,
+  };
+
+  /**
+   * @type {BeforeNewMessageReceivedHookData}
+   */
+  const data = {
+    ...input,
+
+    cancel() {
+      result.cancelled = true;
+    },
+  };
+
+  for (const hook of beforeNewMessageReceivedHooks) {
+    await hook(data);
+  }
+
+  return result;
+}
+
+module.exports = {
+  beforeNewMessageReceived: beforeNewMessageReceived,
+  callBeforeNewMessageReceivedHooks: callBeforeNewMessageReceivedHooks,
+};

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,6 +1,7 @@
 const attachments = require("./data/attachments");
 const logs = require("./data/logs");
 const { beforeNewThread } = require("./hooks/beforeNewThread");
+const { beforeNewMessageReceived } = require("./hooks/beforeNewMessageReceived");
 const { afterThreadClose } = require("./hooks/afterThreadClose");
 const formats = require("./formatters");
 const webserver = require("./modules/webserver");
@@ -151,6 +152,7 @@ module.exports = {
       },
       hooks: {
         beforeNewThread,
+        beforeNewMessageReceived,
         afterThreadClose,
       },
       formats,


### PR DESCRIPTION
I added the channel name in the hook that's called before a thread is created so now we can modify the channel name with a plugin (like add a prefix for example)