### PR TITLE
Fixing crash on Discovery enabled servers for usernames which are not allowed in Channelnames

### DIFF
--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -218,11 +218,10 @@ async function createNewThreadForUser(user, opts = {}) {
           });
         } catch (err) {
           console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}!`);
-          }
           throw err;
         }
-        // Discovery Fix end
       }
+        // Discovery Fix end
       throw err;
     }
 

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -210,7 +210,7 @@ async function createNewThreadForUser(user, opts = {}) {
       // Fix for Discovery Servers censored channel names
       console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}! Trying to workaround the Discovery Server limitations.`);
       if (err.message.indexOf('Contains words not allowed for servers in Server Discovery') !== -1) {
-        let channelName = `badname-${user.discriminator}`;
+        let channelName = `badname-0000`;
         try {
           createdChannel = await utils.getInboxGuild().createChannel(channelName, DISOCRD_CHANNEL_TYPES.GUILD_TEXT, {
             reason: "New Modmail thread",

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -207,22 +207,24 @@ async function createNewThreadForUser(user, opts = {}) {
         parentID: newThreadCategoryId,
       });
     } catch (err) {
-      console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}!`);
-      // Fix for Discovery Servers
-      if (err.includes('Contains words not allowed for servers in Server Discovery')) {
-        let channelName = `BadName-${user.discriminator}`;
+      // Fix for Discovery Servers censored channel names
+      console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}! Trying to workaround the Discovery Server limitations.`);
+      if (err.message.indexOf('Contains words not allowed for servers in Server Discovery') !== -1) {
+        let channelName = `badname-${user.discriminator}`;
         try {
           createdChannel = await utils.getInboxGuild().createChannel(channelName, DISOCRD_CHANNEL_TYPES.GUILD_TEXT, {
             reason: "New Modmail thread",
             parentID: newThreadCategoryId,
           });
         } catch (err) {
-          console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}!`);
+          console.error(`Error creating modmail channel for BadName User ${user.username}#${user.discriminator}!`);
           throw err;
         }
       }
+      if (!createdChannel.id) {
+        throw err;
+      }
         // Discovery Fix end
-      throw err;
     }
 
     // Save the new thread in the database

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -208,6 +208,21 @@ async function createNewThreadForUser(user, opts = {}) {
       });
     } catch (err) {
       console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}!`);
+      // Fix for Discovery Servers
+      if (err.includes('Contains words not allowed for servers in Server Discovery')) {
+        let channelName = `BadName-${user.discriminator}`;
+        try {
+          createdChannel = await utils.getInboxGuild().createChannel(channelName, DISOCRD_CHANNEL_TYPES.GUILD_TEXT, {
+            reason: "New Modmail thread",
+            parentID: newThreadCategoryId,
+          });
+        } catch (err) {
+          console.error(`Error creating modmail channel for ${user.username}#${user.discriminator}!`);
+          }
+          throw err;
+        }
+        // Discovery Fix end
+      }
       throw err;
     }
 


### PR DESCRIPTION
This small fix catches the error message Discord gives for Discovery enabled servers and changes the channel name to „badname“.