### PR TITLE
Fix categoryAutomation.newThread not being in config at all crashing bot

### DIFF
--- a/src/cfg.js
+++ b/src/cfg.js
@@ -149,6 +149,7 @@ if (! config.logOptions) {
   config.logOptions = {};
 }
 
+config.categoryAutomation = config.categoryAutomation || {};
 // categoryAutomation.newThreadFromGuild => categoryAutomation.newThreadFromServer
 if (config.categoryAutomation && config.categoryAutomation.newThreadFromGuild && ! config.categoryAutomation.newThreadFromServer) {
   config.categoryAutomation.newThreadFromServer = config.categoryAutomation.newThreadFromGuild;

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -184,7 +184,7 @@ async function createNewThreadForUser(user, opts = {}) {
     // Figure out which category we should place the thread channel in
     let newThreadCategoryId = (hookResult && hookResult.categoryId) || opts.categoryId || null;
 
-    if (! newThreadCategoryId && config.categoryAutomation.newThreadFromServer) {
+    if (! newThreadCategoryId && config.categoryAutomation?.newThreadFromServer) {
       // Categories for specific source guilds (in case of multiple main guilds)
       for (const [guildId, categoryId] of Object.entries(config.categoryAutomation.newThreadFromServer)) {
         if (userGuildData.has(guildId)) {
@@ -194,7 +194,7 @@ async function createNewThreadForUser(user, opts = {}) {
       }
     }
 
-    if (! newThreadCategoryId && config.categoryAutomation.newThread) {
+    if (! newThreadCategoryId && config.categoryAutomation?.newThread) {
       // Blanket category id for all new threads (also functions as a fallback for the above)
       newThreadCategoryId = config.categoryAutomation.newThread;
     }

--- a/src/data/threads.js
+++ b/src/data/threads.js
@@ -184,7 +184,7 @@ async function createNewThreadForUser(user, opts = {}) {
     // Figure out which category we should place the thread channel in
     let newThreadCategoryId = (hookResult && hookResult.categoryId) || opts.categoryId || null;
 
-    if (! newThreadCategoryId && config.categoryAutomation?.newThreadFromServer) {
+    if (! newThreadCategoryId && config.categoryAutomation.newThreadFromServer) {
       // Categories for specific source guilds (in case of multiple main guilds)
       for (const [guildId, categoryId] of Object.entries(config.categoryAutomation.newThreadFromServer)) {
         if (userGuildData.has(guildId)) {
@@ -194,7 +194,7 @@ async function createNewThreadForUser(user, opts = {}) {
       }
     }
 
-    if (! newThreadCategoryId && config.categoryAutomation?.newThread) {
+    if (! newThreadCategoryId && config.categoryAutomation.newThread) {
       // Blanket category id for all new threads (also functions as a fallback for the above)
       newThreadCategoryId = config.categoryAutomation.newThread;
     }


### PR DESCRIPTION
This is probably another change needed because of the ajv update, it is also probably not the last one needed. Will send PRs as I get reports of them.