### PR TITLE
Fix user close

### DIFF
--- a/src/modules/close.js
+++ b/src/modules/close.js
@@ -101,7 +101,7 @@ module.exports = ({ bot, knex, config, commands }) => {
     let silentClose = false;
     let suppressSystemMessages = false;
 
-    if (msg.channel instanceof Eris.PrivateChannel) {
+    if (!msg.guildID) {
       // User is closing the thread by themselves (if enabled)
       if (! config.allowUserClose) return;
       if (await blocked.isBlocked(msg.author.id)) return;


### PR DESCRIPTION
The user close doesn't work in the current code.

This message from a contributor in the official Eris server explains the fix https://discord.com/channels/831967755447828491/831974405701500931/1019431871236546620

![image](https://user-images.githubusercontent.com/83034852/190044961-4cd84dc6-9366-48f8-968e-70b4d0053ea1.png)