### PR TITLE
Add feature: override role name displayed to end user from config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ To do that, use the same format as with "Accepts multiple values" above:
 ```ini
 greetingMessage[] = Welcome to the server!
 greetingMessage[] = This is the second line of the greeting.
-greetingMessage[] = 
+greetingMessage[] =
 greetingMessage[] = Fourth line! With an empty line in the middle.
 ```
 
@@ -299,6 +299,13 @@ If enabled, a system message will be posted into any open threads if the user jo
 #### notifyOnMainServerLeave
 **Default:** `on`  
 If enabled, a system message will be posted into any open threads if the user leaves a main server
+
+#### overrideRoleNameDisplay
+**Default:** *None*
+Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For esample;
+```ini
+overrideRoleNameDisplay = Moderator
+```
 
 #### pingOnBotMention
 **Default:** `on`  

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,7 +302,7 @@ If enabled, a system message will be posted into any open threads if the user le
 
 #### overrideRoleNameDisplay
 **Default:** *None*
-Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For esample;
+Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For example;
 ```ini
 overrideRoleNameDisplay = Moderator
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ To do that, use the same format as with "Accepts multiple values" above:
 ```ini
 greetingMessage[] = Welcome to the server!
 greetingMessage[] = This is the second line of the greeting.
-greetingMessage[] =
+greetingMessage[] = 
 greetingMessage[] = Fourth line! With an empty line in the middle.
 ```
 
@@ -302,10 +302,8 @@ If enabled, a system message will be posted into any open threads if the user le
 
 #### overrideRoleNameDisplay
 **Default:** `None`  
-Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For example;
-```ini
-overrideRoleNameDisplay = Moderator
-```
+Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For example; `overrideRoleNameDisplay = Moderator`
+
 
 #### pingOnBotMention
 **Default:** `on`  

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,7 +301,7 @@ If enabled, a system message will be posted into any open threads if the user jo
 If enabled, a system message will be posted into any open threads if the user leaves a main server
 
 #### overrideRoleNameDisplay
-**Default:** `None`
+**Default:** `None`  
 Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For example;
 ```ini
 overrideRoleNameDisplay = Moderator

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,7 +301,7 @@ If enabled, a system message will be posted into any open threads if the user jo
 If enabled, a system message will be posted into any open threads if the user leaves a main server
 
 #### overrideRoleNameDisplay
-**Default:** *None*
+**Default:** `None`
 Role name to display in all replies. This completely overrides normal role selection, all replies will contain the string entered. For example;
 ```ini
 overrideRoleNameDisplay = Moderator

--- a/src/data/cfg.jsdoc.js
+++ b/src/data/cfg.jsdoc.js
@@ -77,6 +77,7 @@
  * @property {boolean} [errorOnUnknownInlineSnippet=true]
  * @property {boolean} [allowChangingDisplayRole=true]
  * @property {string} [fallbackRoleName=null]
+ * @property {string}  [overrideRoleNameDisplay] Overrides the role displayed on replies
  * @property {boolean} [breakFormattingForNames=true]
  * @property {boolean} [autoAlert=false]
  * @property {string} [autoAlertDelay="2m"] Delay before auto-alert kicks in. Uses the same format as timed close; for example 1m30s for 1 minute and 30 seconds.

--- a/src/data/cfg.schema.json
+++ b/src/data/cfg.schema.json
@@ -400,6 +400,12 @@
       "default": null
     },
 
+    "overrideRoleNameDisplay": {
+      "$comment": "Overrides the role displayed on replies",
+      "type": "string",
+      "default": null
+    },
+
     "breakFormattingForNames": {
       "$ref": "#/definitions/customBoolean",
       "default": true

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -101,7 +101,7 @@ const bot = require("./bot");
  */
 const defaultFormatters = {
   formatStaffReplyDM(threadMessage) {
-    const roleName = threadMessage.role_name || config.fallbackRoleName;
+    const roleName = config.overrideRoleNameDisplay || threadMessage.role_name || config.fallbackRoleName;
     const modInfo = threadMessage.is_anonymous
       ? roleName
       : (roleName ? `(${roleName}) ${threadMessage.user_name}` : threadMessage.user_name);
@@ -112,7 +112,7 @@ const defaultFormatters = {
   },
 
   formatStaffReplyThreadMessage(threadMessage) {
-    const roleName = threadMessage.role_name || config.fallbackRoleName;
+    const roleName = config.overrideRoleNameDisplay || threadMessage.role_name || config.fallbackRoleName;
     const modInfo = threadMessage.is_anonymous
       ? (roleName ? `(Anonymous) (${threadMessage.user_name}) ${roleName}` : `(Anonymous) (${threadMessage.user_name})`)
       : (roleName ? `(${roleName}) ${threadMessage.user_name}` : threadMessage.user_name);


### PR DESCRIPTION
This patch adds a configuration option which will let end users arbitrarily override the role displayed to end users from the config option 
`overrideRoleNameDisplay`

This allows to hide a moderator with a hitched role which is unsuitable to be displayed to end users. In our case, specifically a hidden moderator with a general user role. Not able to use `fallbackRoleName`, because the hidden moderator has a hitched role.

I have not coded in a very long time, and never in JS before, so rusty doesn't even begin to cover it. Thoughts/rejection/comments/patches appreciated :)

I've tested this patch on our server, and it appears to work okay, but have not tested all existing functions exhaustively