### PR TITLE
Add additional information to commandAlias

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,7 +203,8 @@ Note that you can combine different commands and parameters together:
 
 ```ini
 # !replysus is a alias/shortcut for !reply and !suspend
-commandAliases.replysus = reply Thank you for this, we will suspend this thread whilst we conduct our investigations
+commandAliases.replysus = reply Thank you for this, we will suspend this thread whilst we conduct our investigations.
+# The !suspend shortcut is implemented here
 commandAliases.replysus = suspend
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,7 +203,7 @@ Note that you can combine different commands and parameters together:
 
 ```ini
 # !replysus is a alias/shortcut for !reply and !suspend
-commandAliases.replysus = reply Thank you for this. We will suspend this thread whilst we conduct our investigations.
+commandAliases.replysus = reply Thank you for this, we will suspend this thread whilst we conduct our investigations
 commandAliases.replysus = suspend
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,13 @@ commandAliases.mv = move
 # !x is an alias/shortcut for !close
 commandAliases.x = close
 ```
+Note that you can combine different commands and parameters together:
+
+```ini
+# !replysus is a alias/shortcut for !reply and !suspend
+commandAliases.replysus = reply Thank you for this. We will suspend this thread whilst we conduct our investigations.
+commandAliases.replysus = suspend
+```
 
 #### enableGreeting
 **Default:** `off`  


### PR DESCRIPTION
This short but sweet PR closes #789 (thanks @LazyColgate!) by adding additional information about the `commandAlias` configuration option to reflect that multiple commands can be used in one shortcut. 