### PR TITLE
Add timestamps to pm2 logs

### DIFF
--- a/modmailbot-pm2.json
+++ b/modmailbot-pm2.json
@@ -2,6 +2,7 @@
     "apps": [{
         "name": "ModMailBot",
         "cwd": "./",
-        "script": "src/index.js"
+        "script": "src/index.js",
+        "log_date_format": "YYYY-MM-DD HH:mm Z"
     }]
 }


### PR DESCRIPTION
By default, PM2 does not add timestamps to its logs. This PR adds it to allow for easier seeing of when events happen