### PR TITLE
fix: security vurn on new versions of node on windows

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -44,7 +44,7 @@ const pluginSources = {
         const npmProcess = childProcess.spawn(
           npmProcessName,
           ["install", "--verbose", "--no-save", ...finalPluginNames],
-          { cwd: process.cwd() }
+          { cwd: process.cwd(), shell: true }
         );
         npmProcess.stderr.on("data", data => { stderr += String(data) });
         npmProcess.on("close", code => {


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high