### PR TITLE
Fix typingProxy which did not work

### DIFF
--- a/src/modules/typingProxy.js
+++ b/src/modules/typingProxy.js
@@ -12,7 +12,7 @@ module.exports = ({ bot }) => {
       }
 
       // config.typingProxy: forward user typing in a DM to the modmail thread
-      if (config.typingProxy && (channel instanceof Eris.PrivateChannel)) {
+      if (config.typingProxy && !(channel instanceof Eris.GuildChannel)) {
         const thread = await threads.findOpenThreadByUserId(user.id);
         if (! thread) return;
 


### PR DESCRIPTION
I fixed an issue with the TypingProxy module that just wasn't working at all. The problem was that the "if" which checks that typingProxy is enabled in the config file, was trying to check that the "channel" parameter was an instance of the Eris PrivateChannel class. However, it always returned False due to a problem in Eris's code.

if (config.typingProxy && (channel instanceof Eris.PrivateChannel) TO if (config.typingProxy && !(channel instanceof Eris.GuildChannel))

**To solve** this problem, I simply checked that the "channel" was not a server message and it worked.