### PR TITLE
Add reminder command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -116,6 +116,18 @@ Prints the ID of the current DM channel with the user
 Shows the DM channel ID, DM message ID, and message link of the specified user reply.
 `<number>` is the message number shown in front of staff replies in the thread channel.
 
+### `!rem <HH:MM> <reason>`
+Adds a reminder for a task. You will be pinged as soon as the time is reached.
+The reminder is stored in the database so if you restart the bot, the reminders remain active.
+After you set up a reminder, the bot confirms it and gives you the reminder ID.
+
+**Example:** `!rem 18:40 Help this people`
+
+### `!delrem <ID>`
+Delete a reminder via its ID
+
+**Example:** `!delrem 18`
+
 ## Anywhere on the inbox server
 These commands can be used anywhere on the inbox server, even outside Modmail threads.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "tmp": "^0.2.1",
     "transliteration": "^2.3.5",
     "uuid": "^9.0.1",
-    "yargs-parser": "^21.1.1"
+    "yargs-parser": "^21.1.1",
+    "cron": "^3.1.7"
   },
   "devDependencies": {
     "eslint": "^8.49.0",

--- a/src/data/migrations/20171223203915_create_tables.js
+++ b/src/data/migrations/20171223203915_create_tables.js
@@ -43,6 +43,18 @@ exports.up = async function(knex, Promise) {
       table.dateTime("created_at").notNullable();
     });
   }
+
+  if (! await knex.schema.hasTable("reminders")) {
+    await knex.schema.createTable("reminders", table => {
+      table.increments('id').primary();
+      table.string('thread_id').notNullable();
+      table.string('user_id').notNullable();
+      table.timestamp('reminder_time').notNullable();
+      table.text('message').notNullable();
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+    });
+  }
 };
 
 exports.down = async function(knex, Promise) {
@@ -60,5 +72,9 @@ exports.down = async function(knex, Promise) {
 
   if (await knex.schema.hasTable("snippets")) {
     await knex.schema.dropTable("snippets");
+  }
+
+  if (await knex.schema.hasTable("reminders")) {
+    await knex.schema.dropTable("reminders");
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -374,6 +374,7 @@ function getBasePlugins() {
     "file:./src/modules/joinLeaveNotification",
     "file:./src/modules/roles",
     "file:./src/modules/notes",
+    "file:./src/modules/reminder",
   ];
 }
 

--- a/src/modules/reminder.js
+++ b/src/modules/reminder.js
@@ -1,0 +1,102 @@
+const { CronJob } = require('cron');
+const threads = require("../data/threads");
+
+const reminderJobs = {};
+
+async function loadReminders(knex, bot) {
+  const reminders = await knex('reminders').select('*');
+  for (const reminder of reminders) {
+    const { id, thread_id, user_id, reminder_time, message } = reminder;
+    const alertTime = new Date(reminder_time);
+    const now = new Date();
+
+    if (alertTime > now) {
+      const cronTime = `${alertTime.getUTCMinutes()} ${alertTime.getUTCHours()} * * *`;
+      const job = new CronJob(cronTime, async () => {
+        const thread = await threads.findById(thread_id);
+        if (thread) {
+          await thread.postSystemMessage(`<@!${user_id}> Rappel : ${message}`);
+        }
+        job.stop();
+        delete reminderJobs[id];
+      }, null, true, 'UTC');
+
+      reminderJobs[id] = job;
+    }
+  }
+}
+
+module.exports = async ({ bot, knex, config, commands }) => {
+
+  await loadReminders(knex, bot);
+
+  commands.addInboxThreadCommand("rem", [{name: "message", type: "string", catchAll: true}], async (msg, args, thread) => {
+    
+    const messageParts = args.message.split(" ");
+    const timePart = messageParts.shift();
+    const reminderMessage = messageParts.join(" ");
+
+    const timeMatch = timePart.match(/^(\d{1,2}):(\d{2})$/);
+    if (!timeMatch) {
+      await thread.postSystemMessage("Incorrect format. Use: `!rem HH:MM message`");
+      return;
+    }
+
+    const hour = parseInt(timeMatch[1], 10) - 2;
+    const minute = parseInt(timeMatch[2], 10);
+    const realHour = parseInt(timeMatch[1], 10);
+
+    if (isNaN(hour) || hour < 0 || hour > 23 || isNaN(minute) || minute < 0 || minute > 59) {
+      await thread.postSystemMessage("Invalid time. Use: `!rem HH:MM message`");
+      return;
+    }
+
+    const now = new Date();
+    let alertTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute);
+    let realAlertTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), realHour, minute);
+
+    if (alertTime < now) {
+      alertTime.setDate(alertTime.getDate() + 1);
+    }
+
+    const alertTimeUtc = alertTime.toISOString();
+
+    const [reminder] = await knex('reminders').insert({
+      thread_id: thread.id,
+      user_id: msg.author.id,
+      reminder_time: alertTimeUtc,
+      message: reminderMessage
+    }).returning('id');
+
+    const reminderId = reminder.id;
+
+    const cronTime = `${minute} ${hour} * * *`;
+    const job = new CronJob(cronTime, async () => {
+      await thread.postSystemMessage(`⏰ **REMINDER** <@${msg.author.id}> : \n\n >>> ${reminderMessage}`, {
+        allowedMentions: {
+          users: [msg.author.id],
+        },
+      });
+      job.stop();
+      delete reminderJobs[reminderId];
+    }, null, true, 'UTC');
+
+    reminderJobs[reminderId] = job;
+
+    await thread.postSystemMessage(`**⏰ Reminder set for ${realAlertTime.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })} :** \n\n > ${reminderMessage} \n\n **(ID: ${reminderId})**`);
+  }, { allowSuspended: true });
+
+  commands.addInboxThreadCommand("delrem", [{name: "id", type: "number"}], async (msg, args, thread) => {
+    await knex('reminders')
+      .where({ id: args.id, thread_id: thread.id })
+      .delete();
+
+    if (reminderJobs[args.id]) {
+      reminderJobs[args.id].stop();
+      delete reminderJobs[args.id];
+    }
+
+    await thread.postSystemMessage(`The reminder with ID **${args.id}** has been deleted.`);
+  }, { allowSuspended: true });
+
+};


### PR DESCRIPTION
This pull request adds a new reminder command to the bot, allowing users to set reminders that will be sent as mentions at specified times. The reminders are stored in a database and scheduled using cron. The following changes were made:

1. **New Command:** Added a `!rem` command that takes a time (HH:MM) and a message as arguments. The command schedules a reminder at the specified time and stores the reminder in the database.

2. **Cron Job Scheduling:** Implemented **_cron jobs_** to handle the scheduled reminders. When a reminder is due, the bot sends a message mentioning the user who set the reminder. The cron module is included in the _"package.json"_.

3. **Database Integration:** Stored reminders in a database table named reminders. Each reminder includes the thread ID, user ID, reminder time, and message. If the table does not exist, it is automatically created when the bot starts.

4. **Allowed Mentions:** Ensured that user mentions in reminder messages are **active** by using the `allowedMentions` parameter when sending messages.

5. **Deletion Command:** Added a `!delrap` command to delete a scheduled reminder by its ID. This stops the associated cron job and removes the reminder from the database.

# How to Use

- **Set a Reminder:** Use the command `!rem HH:MM message` to set a reminder. The bot will confirm the scheduled time and message.

- **Delete a Reminder:** Use the command `!delrap ID` to delete a reminder by its **ID**.

# Example

- To set a reminder for 14:30, use: `!rem 14:30 Don't forget the meeting!`
- To delete a reminder with ID 1, use: `!delrap 1`

# Code Changes
The following files were modified:

- **[docs/command.md](https://github.com/Akinator31/modmailbot_fixs/commit/dcb98fc947b3e178c7bebe2e78d5f252804e15e0#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905e):** Added the "reminder" command to the documentation.

- **[package.json](https://github.com/Akinator31/modmailbot_fixs/commit/dcb98fc947b3e178c7bebe2e78d5f252804e15e0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519):** Added “cron” module

- **[src/data/migrations/20171223203915_create_tables.js](https://github.com/Akinator31/modmailbot_fixs/commit/dcb98fc947b3e178c7bebe2e78d5f252804e15e0#diff-ece3ec2afd7e4b2d185eef2525cbd9724088a2f5c3cf965c34c8ac5f3bb9923a):** Added a migration for the reminders table.

- **[src/main.js](https://github.com/Akinator31/modmailbot_fixs/commit/dcb98fc947b3e178c7bebe2e78d5f252804e15e0#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79):** Added reminder module to main.js

- **[src/modules/reminder.js](https://github.com/Akinator31/modmailbot_fixs/commit/dcb98fc947b3e178c7bebe2e78d5f252804e15e0#diff-d163172d89c6ae5d6ef6ce38f5b3e2a1eed334e33953a23ca9a707c9417ea3a4):** Added reminder command

# Testing

- Verified that reminders are stored in the database and scheduled correctly.

- Ensured that reminders are sent as mentions at the correct times.

- Tested the deletion of reminders and confirmed that the associated cron jobs are stopped.

- Tested that reminders still work after restarting the bot

Do not hesitate to notify me of any problems.