### PR TITLE
Add template command

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -374,6 +374,7 @@ function getBasePlugins() {
     "file:./src/modules/joinLeaveNotification",
     "file:./src/modules/roles",
     "file:./src/modules/notes",
+    "file:./src/modules/template",
   ];
 }
 

--- a/src/modules/template.js
+++ b/src/modules/template.js
@@ -1,0 +1,47 @@
+const threads = require("../data/threads");
+
+module.exports = async ({ bot, knex, config, commands }) => {
+
+  commands.addInboxThreadCommand("addtemplate", [{ name: "name", type: "string" }, { name: "content", type: "string", catchAll: true }], async (msg, args, thread) => {
+    await knex('templates').insert({
+      name: args.name,
+      content: args.content
+    });
+
+    await thread.postSystemMessage(`Template **${args.name}** created.`);
+  }, { allowSuspended: true });
+
+  commands.addInboxThreadCommand("listtemplates", [], async (msg, args, thread) => {
+    const templates = await knex('templates').select('*');
+    if (templates.length === 0) {
+      await thread.postSystemMessage("No templates found.");
+      return;
+    }
+
+    const templateList = templates.map(t => `**${t.name}**: ${t.content}`).join('\n\n');
+    await thread.postSystemMessage(`Templates available:\n\n${templateList}`);
+  }, { allowSuspended: true });
+
+  commands.addInboxThreadCommand("template", [{ name: "name", type: "string" }], async (msg, args, thread) => {
+    const template = await knex('templates').where('name', args.name).first();
+    if (!template) {
+      await thread.postSystemMessage(`Template **${args.name}** not found.`);
+      return;
+    }
+
+    const templateContent = template.content;
+
+    const replied = await thread.replyToUser(msg.member, templateContent, [], config.forceAnon);
+    if (replied) msg.delete();
+  }, { allowSuspended: true });
+
+  commands.addInboxThreadCommand("deltemplate", [{ name: "name", type: "string" }], async (msg, args, thread) => {
+    const rowsDeleted = await knex('templates').where('name', args.name).delete();
+    if (rowsDeleted === 0) {
+      await thread.postSystemMessage(`Template **${args.name}** not found.`);
+      return;
+    }
+
+    await thread.postSystemMessage(`Template **${args.name}** deleted.`);
+  }, { allowSuspended: true });
+};


### PR DESCRIPTION

### Feature: `!template` Command for Pre-written Responses

#### Overview

This pull request introduces the `!template` command, allowing moderators to send pre-written responses to users. The templates are stored in a database table and can be easily managed. This feature aims to help moderators quickly respond to common queries or provide standard information without typing the same messages repeatedly.

#### How to Use

1. **Add a Template:**

   To add a new template to the database, use `!addtemplate [template name] [template message]`. For example:
   ```sh
   !template welcome Hello there.
   ```

2. **Send a Template Response:**

   Use the `!template <templateName>` command within a Modmail thread to send a pre-written response to the user. For example:
   ```sh
   !template welcome
   ```

   This command will fetch the template named "welcome" from the database and send its content as a reply to the user.

- You can also use the `!listtemplates` command to display all saved templates.
- And `!deltemplate [ID]` to delete a template with his ID.

#### Database Schema

Run the following SQL script to create the `templates` table:
```sql
CREATE TABLE templates (
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    content TEXT NOT NULL
);
```

#### Implementation Details

The `!template` command has been added to the bot's command set and works as follows:

- Fetches the specified template from the database using the provided template name.
- Sends the template content as a reply to the user via the Modmail thread.

#### Example Use Cases

- **Welcome Message:** Quickly send a standardized welcome message to new users.
  ```sh
  !template welcome
  ```

- **Rules Reminder:** Send a predefined message reminding users of server rules.
  ```sh
  !template rules
  ```

- **Support Info:** Provide users with standard support information.
  ```sh
  !template support
  ```

#### Testing

To ensure the command works as expected:
1. Add some templates to your database.
2. Open a Modmail thread and use the `!template` command with the name of a template.
3. Verify that the user receives the correct pre-written response.

Do not hesitate to notify me of any problems.
