### PR TITLE
add closed by author ID in log message

### DIFF
--- a/src/modules/close.js
+++ b/src/modules/close.js
@@ -177,7 +177,7 @@ module.exports = ({ bot, knex, config, commands }) => {
 
     await thread.close(suppressSystemMessages, silentClose);
 
-    await sendCloseNotification(thread, `Modmail thread #${thread.thread_number} with ${thread.user_name} (${thread.user_id}) was closed by ${closedBy}`);
+    await sendCloseNotification(thread, `Modmail thread #${thread.thread_number} with ${thread.user_name} (${thread.user_id}) was closed by ${closedBy} (${msg.author.id})`);
   }, {
     options: [
       { name: "silent", shortcut: "s", isSwitch: true },


### PR DESCRIPTION
Hello, pretty simple change here which should just make it a bit easier to keep track of which thread was closed by whom. 

This has recently become an issue for us on the Overwatch 2 server when collecting stats and collating data, since a number of mods change display names now-and-again. 

This also makes the message a bit more consistent, giving the ID for both thread recipient and closer.  

Thanks!