### PR TITLE
Add missing "net" module in utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const Eris = require("eris");
+const net = require("net")
 const bot = require("./bot");
 const moment = require("moment");
 const humanizeDuration = require("humanize-duration");


### PR DESCRIPTION
Needed for getSelfUrl() function's isIPv6 call 