### PR TITLE
fix: support cross-filesystem local attachment storage

### DIFF
--- a/src/data/attachments.js
+++ b/src/data/attachments.js
@@ -95,7 +95,14 @@ saveLocalAttachment = async (attachment) => {
   const downloadResult = await downloadAttachment(attachment);
 
   // Move the temp file to the attachment folder
-  await fsp.rename(downloadResult.path, targetPath);
+  try {
+    await fsp.rename(downloadResult.path, targetPath);
+  } catch (err) {
+    if (err.code !== "EXDEV") throw err;
+
+    await fsp.copyFile(downloadResult.path, targetPath);
+    await fsp.unlink(downloadResult.path);
+  }
 
   // Resolve the attachment URL
   const url = await getLocalAttachmentUrl(attachment.id, attachment.filename);


### PR DESCRIPTION
## Summary

- Keep `fs.promises.rename()` for normal local attachment moves
- Fall back to copying the file and removing the source when `rename()` fails with `EXDEV`

## Context

This restores cross-filesystem behavior lost in v3.11.0 when `mv` was replaced with `fs.promises.rename()`. The failure occurs when the system temp directory and the configured attachment directory are on different filesystems, matching the deployment case previously reported in #276

## Verification

- Used a local harness to force `rename()` to return `EXDEV`
- Confirmed the attachment was copied to the target path and the source temp file was removed
- Ran `node --check src/data/attachments.js`
