### PR TITLE
fix: clear failed attachment save promises

### DIFF
--- a/src/data/attachments.js
+++ b/src/data/attachments.js
@@ -243,7 +243,7 @@ const saveAttachment = (attachment) => {
     throw new Error(`Unknown attachment storage option: ${config.attachmentStorage}`);
   }
 
-  attachmentSavePromises[attachment.id].then(() => {
+  attachmentSavePromises[attachment.id] = attachmentSavePromises[attachment.id].finally(() => {
     delete attachmentSavePromises[attachment.id];
   });
 


### PR DESCRIPTION
## Summary

- Clear cached attachment-save promises after both success and failure
- Return the cleanup chain instead of creating a detached rejected promise

## Context

`saveAttachment()` currently starts a success-only `.then()` cleanup without returning that promise. When an attachment save rejects, the caller can catch the original rejection while the detached promise still becomes an `unhandledRejection`. The rejected save also remains cached, so later calls for the same attachment immediately receive the same rejection.

Assigning and returning the `.finally()` chain runs cleanup for both outcomes while preserving the original result or error for the caller. This is separate from #876, which fixed one specific attachment-storage failure but did not change promise cleanup.

## Verification

- Used a disposable local harness to verify a failed save is no longer cached
- Confirmed a caller-handled save failure does not create an unhandled rejection
- Ran `node --check src/data/attachments.js`
- Ran `git diff --check`

No test files or dependencies are included in this change.