### PR TITLE
fix: skip recovery without a latest thread message

### DIFF
--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -1170,7 +1170,10 @@ class Thread {
     const dmChannel = await bot.getDMChannel(this.user_id);
     if (! dmChannel) return;
 
-    const lastMessageId = (await this.getLatestThreadMessage()).dm_message_id;
+    const latestThreadMessage = await this.getLatestThreadMessage();
+    if (! latestThreadMessage) return;
+
+    const lastMessageId = latestThreadMessage.dm_message_id;
     let messages = (await dmChannel.getMessages(50, null, lastMessageId, null))
       .reverse() // We reverse the array to send the messages in the proper order - Discord returns them newest to oldest
       .filter(msg => msg.author && msg.author.id === this.user_id); // Make sure we're not recovering bot or system messages (author can be missing for partial payloads)


### PR DESCRIPTION
## Summary

- Skip downtime-message recovery when an open thread has no latest user-facing database message

## Context

`getLatestThreadMessage()` can return no row for an open thread with no qualifying user-facing messages. `recoverDowntimeMessages()` currently reads `dm_message_id` unconditionally, causing a `TypeError` during startup recovery.

The existing per-thread error handler keeps Modmail online, but the same thread produces the same error after each restart.

## Verification

- Used a disposable local harness to reproduce the missing-message `TypeError`
- Verified the guard returns before requesting Discord history when no recovery cursor exists
- Ran `node --check src/data/Thread.js`
- Ran `git diff --check`

No test files or dependencies are included in this change.